### PR TITLE
usbsdmux: fix invalid call of 'args' variable in conditional

### DIFF
--- a/usbsdmux/__main__.py
+++ b/usbsdmux/__main__.py
@@ -12,7 +12,7 @@ def direct_mode(sg, mode):
 
     if mode.lower() == "off":
         ctl.mode_disconnect()
-    elif mode.lower() == "dut" or args.mode.lower() == "client":
+    elif mode.lower() == "dut" or mode.lower() == "client":
         ctl.mode_DUT()
     elif mode.lower() == "host":
         ctl.mode_host()


### PR DESCRIPTION
Calling usbsdmux in direct mode with argument 'host' causes an error:

    Traceback (most recent call last):
      File "venv/bin/usbsdmux", line 10, in <module>
        sys.exit(main())
      File "/home/ejo/Code/usbsdmux/venv/lib/python3.5/site-packages/usbsdmux-0.1.4-py3.5.egg/usbsdmux/__main__.py", line 69, in main
      File "/home/ejo/Code/usbsdmux/venv/lib/python3.5/site-packages/usbsdmux-0.1.4-py3.5.egg/usbsdmux/__main__.py", line 15, in direct_mode
    NameError: name 'args' is not defined

The variable 'args' of main function is not accessible from function
'direct_mode', but we have the mode passed as parameter anyway and can
use this instead.

Signed-off-by: Enrico Jorns <ejo@pengutronix.de>