### PR TITLE
Fixing size check of sgio for armv7

### DIFF
--- a/usbsdmux/usb2642i2c.py
+++ b/usbsdmux/usb2642i2c.py
@@ -285,6 +285,8 @@ class Usb2642I2C(object):
                   info=0)
     if platform.machine() == "i686":
       assert ctypes.sizeof(sgio) == 64
+    elif platform.machine() == "armv7l":
+      assert ctypes.sizeof(sgio) == 64
     else:
       assert ctypes.sizeof(sgio) == 88
     return sgio, sense


### PR DESCRIPTION
The struct sg_io_hdr has a different size depending on the platform.
This adds a test case for armv7l.
A better way may be to check against the pointer size of platform but i
can not test this atm.